### PR TITLE
chore: remove linter and test calls from pipeline

### DIFF
--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -38,12 +38,6 @@ jobs:
         run: make download-oas
       - name: Generate SDK
         run: make generate-sdk
-      - name: Lint
-        working-directory: ./sdk-repo-updated
-        run: make lint skip-non-generated-files=true
-      - name: Test
-        working-directory: ./sdk-repo-updated
-        run: make test skip-non-generated-files=true
       - name: Push SDK
         env:
           GH_REPO: "stackitcloud/stackit-sdk-go"
@@ -86,16 +80,6 @@ jobs:
           python -m venv ${{ runner.temp }}/.venv
           source ${{ runner.temp }}/.venv/bin/activate
           make install-dev
-      - name: Lint Python
-        working-directory: ./sdk-repo-updated
-        run: |
-          source ${{ runner.temp }}/.venv/bin/activate
-          make lint           
-      - name: Test Python
-        working-directory: ./sdk-repo-updated
-        run: |
-          source ${{ runner.temp }}/.venv/bin/activate
-          make test                    
       - name: Push Python SDK
         env:
           GH_REPO: "stackitcloud/stackit-sdk-python"


### PR DESCRIPTION
The sdk generator will do linter and tests individually without breaking the pipeline on the first issue