### PR TITLE
feat(java): Add Java SDK generation step to pipeline

### DIFF
--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "stackitcloud/stackit-sdk-generator"
-          ref: "bf/add-javasdk-to-pipeline"
+          ref: "main"
       - name: Build
         uses: ./.github/actions/build/java
         with:

--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "stackitcloud/stackit-sdk-generator"
-          ref: "main"
+          ref: "bf/add-javasdk-to-pipeline"
       - name: Build
         uses: ./.github/actions/build/java
         with:

--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -102,7 +102,7 @@ jobs:
           distribution: "temurin"
           java-version: ${{ env.JAVA_VERSION }}
       - name: Checkout generator repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: "stackitcloud/stackit-sdk-generator"
           ref: "main"

--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -86,3 +86,41 @@ jobs:
           GH_TOKEN: ${{ secrets.SDK_PR_TOKEN }}
         run: |
           scripts/sdk-create-pr.sh "generator-bot-${{ github.run_id }}" "Generated from GitHub run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" "git@github.com:stackitcloud/stackit-sdk-python.git" "python"
+
+  main-java:
+    name: "[Java] Update SDK Repo"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ vars.SSH_KNOWN_HOSTS }}
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ env.JAVA_VERSION }}
+      - name: Checkout generator repo
+        uses: actions/checkout@v3
+        with:
+          repository: "stackitcloud/stackit-sdk-generator"
+          ref: "main"
+      - name: Build
+        uses: ./.github/actions/build/java
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Download OAS
+        run: make download-oas
+      - name: Generate SDK
+        run: make generate-sdk LANGUAGE=java
+      - name: Install Java SDK
+        working-directory: ./sdk-repo-updated
+        run: |
+          make install-dev
+      - name: Push Java SDK
+        env:
+          GH_REPO: "stackitcloud/stackit-sdk-java"
+          GH_TOKEN: ${{ secrets.SDK_PR_TOKEN }}
+        run: |
+          scripts/sdk-create-pr.sh "generator-bot-${{ github.run_id }}" "Generated from GitHub run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" "git@github.com:stackitcloud/stackit-sdk-java.git" "java"

--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -114,10 +114,6 @@ jobs:
         run: make download-oas
       - name: Generate SDK
         run: make generate-sdk LANGUAGE=java
-      - name: Install Java SDK
-        working-directory: ./sdk-repo-updated
-        run: |
-          make install-dev
       - name: Push Java SDK
         env:
           GH_REPO: "stackitcloud/stackit-sdk-java"


### PR DESCRIPTION
### Description
In this PR the Pipeline of stackit-api-specifications got extended by a job for the java sdk generation.

But to make it fully work the stackit-sdk-generator needs adjustments too.
Soo this PR is only half of the work and will temporarily (fail/not be complete) until the corresponding changes were made in the stackit-sdk-generator aswell. (Especially testing and linting steps)

The Generation of Go and Python sdk will remain working fine.

### Testing Instructions:

1. Run "Update SDK Repo Workflow" manually on branch "bf/add-javasdk-to-pipeline" (sdk-pr.yaml)
2. Look at PullRequests of https://github.com/stackitcloud/stackit-sdk-java and check if the resource manager service got a new Pull Request with new changes in it. (Its meant to be only the RM-service yet)

### Todos when tested successfully:
- [x] In sdk-pr.yaml the checkout branch of the stackit-sdk-generator needs to be changed to main before merging

