### PR TITLE
ci: SDK pipeline hardening using custom action and commit hashes instead of tags

### DIFF
--- a/.github/actions/install-ssh-key/action.yaml
+++ b/.github/actions/install-ssh-key/action.yaml
@@ -1,0 +1,33 @@
+name: Install SSH Key
+description: Install an SSH private key, known_hosts entries, and optional SSH config.
+inputs:
+  key:
+    description: SSH private key content
+    required: true
+  known_hosts:
+    description: known_hosts content or "unnecessary" to skip custom entries
+    required: true
+  name:
+    description: SSH key filename under ~/.ssh/
+    required: false
+    default: id_rsa
+  config:
+    description: Optional SSH config content to append to ~/.ssh/config
+    required: false
+    default: ""
+  if_key_exists:
+    description: What to do if the target key file already exists
+    required: false
+    default: fail
+runs:
+  using: composite
+  steps:
+    - name: Install SSH key material
+      shell: bash
+      env:
+        INPUT_KEY: ${{ inputs.key }}
+        INPUT_KNOWN_HOSTS: ${{ inputs.known_hosts }}
+        INPUT_NAME: ${{ inputs.name }}
+        INPUT_CONFIG: ${{ inputs.config }}
+        INPUT_IF_KEY_EXISTS: ${{ inputs.if_key_exists }}
+      run: ${{ github.action_path }}/install.sh

--- a/.github/actions/install-ssh-key/install.sh
+++ b/.github/actions/install-ssh-key/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+home_dir="${HOME:?HOME must be set}"
+ssh_dir="${home_dir}/.ssh"
+key_name="${INPUT_NAME:-id_rsa}"
+key_path="${ssh_dir}/${key_name}"
+known_hosts_path="${ssh_dir}/known_hosts"
+config_path="${ssh_dir}/config"
+if_key_exists="${INPUT_IF_KEY_EXISTS:-fail}"
+
+mkdir -p "${ssh_dir}"
+chmod 700 "${ssh_dir}"
+
+if [[ -e "${key_path}" ]]; then
+  case "${if_key_exists}" in
+    replace)
+      ;;
+    ignore)
+      exit 0
+      ;;
+    fail)
+      echo "SSH key already exists at ${key_path}" >&2
+      exit 1
+      ;;
+    *)
+      echo "Unsupported if_key_exists value: ${if_key_exists}" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+umask 077
+printf '%s\n' "${INPUT_KEY}" > "${key_path}"
+chmod 600 "${key_path}"
+
+touch "${known_hosts_path}"
+chmod 600 "${known_hosts_path}"
+
+if ! ssh-keyscan -H github.com >> "${known_hosts_path}" 2>/dev/null; then
+  echo "Failed to fetch github.com host keys" >&2
+  exit 1
+fi
+
+if [[ "${INPUT_KNOWN_HOSTS:-}" != "unnecessary" ]]; then
+  printf '%s\n' "${INPUT_KNOWN_HOSTS}" >> "${known_hosts_path}"
+fi
+
+if [[ -n "${INPUT_CONFIG:-}" ]]; then
+  touch "${config_path}"
+  chmod 600 "${config_path}"
+  printf '%s\n' "${INPUT_CONFIG}" >> "${config_path}"
+fi

--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -7,51 +7,64 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION:   "1.25"
   JAVA_VERSION: "17"
+  UV_VERSION:   "0.10.4"
 
 jobs:
   main-go:
     name: "[Go] Update SDK Repo"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout workflow repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: workflow-repo
+          sparse-checkout: |
+            .github/actions/install-ssh-key
+
       - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2
+        uses: ./workflow-repo/.github/actions/install-ssh-key
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: ${{ vars.SSH_KNOWN_HOSTS }}
       
       - name: Install Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "temurin"
           java-version: ${{ env.JAVA_VERSION }}
       
       - name: Checkout generator repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "stackitcloud/stackit-sdk-generator"
           ref: "main"
+          path: generator-repo
       
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       
       - name: Install project tools and dependencies
         shell: bash
+        working-directory: ./generator-repo
         run: make project-tools
       
       - name: Download OAS
+        working-directory: ./generator-repo
         run: make download-oas
       
       - name: Generate SDK
+        working-directory: ./generator-repo
         run: make generate-go-sdk
       
       - name: Push SDK
         env:
           GH_REPO: "stackitcloud/stackit-sdk-go"
           GH_TOKEN: ${{ secrets.SDK_PR_TOKEN }}
+        working-directory: ./generator-repo
         run: |
           scripts/sdk-create-pr.sh "oas-bot-${{ github.run_id }}" "Generated from GitHub run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
@@ -59,31 +72,40 @@ jobs:
     name: "[Python] Update SDK Repo"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout workflow repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: workflow-repo
+          sparse-checkout: |
+            .github/actions/install-ssh-key
+
       - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2
+        uses: ./workflow-repo/.github/actions/install-ssh-key
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: ${{ vars.SSH_KNOWN_HOSTS }}
       
       - name: Install Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "temurin"
           java-version: ${{ env.JAVA_VERSION }}
       
       - name: Checkout generator repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "stackitcloud/stackit-sdk-generator"
           ref: "main"
+          path: generator-repo
       
       - name: install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.10.4"
+          version: ${{ env.UV_VERSION }}
       
       - name: Install project tools and dependencies
         shell: bash
+        working-directory: ./generator-repo
         run: |
           python -m venv .venv
           . .venv/bin/activate
@@ -91,19 +113,22 @@ jobs:
           make project-tools LANGUAGE=python
       
       - name: Download OAS
+        working-directory: ./generator-repo
         run: make download-oas
       
       - name: Generate SDK
+        working-directory: ./generator-repo
         run: make generate-python-sdk
       
       - name: Install Python SDK
-        working-directory: ./sdk-repo-updated
+        working-directory: ./generator-repo/sdk-repo-updated
         run: make install-dev
       
       - name: Push Python SDK
         env:
           GH_REPO: "stackitcloud/stackit-sdk-python"
           GH_TOKEN: ${{ secrets.SDK_PR_TOKEN }}
+        working-directory: ./generator-repo
         run: |
           scripts/sdk-create-pr.sh "generator-bot-${{ github.run_id }}" "Generated from GitHub run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" "git@github.com:stackitcloud/stackit-sdk-python.git" "python"
 
@@ -111,8 +136,15 @@ jobs:
     name: "[Java] Update SDK Repo"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout workflow repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: workflow-repo
+          sparse-checkout: |
+            .github/actions/install-ssh-key
+
       - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2
+        uses: ./workflow-repo/.github/actions/install-ssh-key
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: ${{ vars.SSH_KNOWN_HOSTS }}
@@ -124,20 +156,24 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       
       - name: Checkout generator repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "stackitcloud/stackit-sdk-generator"
           ref: "main"
+          path: generator-repo
       
       - name: Download OAS
+        working-directory: ./generator-repo
         run: make download-oas
       
       - name: Generate SDK
+        working-directory: ./generator-repo
         run: make generate-java-sdk
       
       - name: Push Java SDK
         env:
           GH_REPO: "stackitcloud/stackit-sdk-java"
           GH_TOKEN: ${{ secrets.SDK_PR_TOKEN }}
+        working-directory: ./generator-repo
         run: |
           scripts/sdk-create-pr.sh "generator-bot-${{ github.run_id }}" "Generated from GitHub run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" "git@github.com:stackitcloud/stackit-sdk-java.git" "java"


### PR DESCRIPTION
In light of recent events on GitHub, NPM and the whole Open Source ecosystem we shouldn't rely on random github actions like `shimataro/ssh-key-action@v2` for simple tasks such as adding an SSH key and known hosts. As well as use git commit hashes instead of tags to ensure we don't fall victim to a repository / org takeover as has happened with fake Trivy tags